### PR TITLE
Fix typo in page heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
 <body>
 
-    <h1 class="some-heading">GIT WORKFLOW WORKSHOW</h1>
+    <h1 class="some-heading">GIT WORKFLOW WORKSHOP</h1>
 
 </body>
 


### PR DESCRIPTION
> Relates #<3>
fixed the typo in the page heading from workshow to workshop